### PR TITLE
PR: Expand concurrency to benefit from parallelism

### DIFF
--- a/BrownLegoCSS.go
+++ b/BrownLegoCSS.go
@@ -447,7 +447,7 @@ func (c *CssCompressor) performGeneralCleanup() {
 	c.Css = re.ReplaceAll(c.Css, []byte(""))
 }
 
-func (c *CssCompressor) Compress() string {
+func (c *CssCompressor) Compress() []byte {
 	c.extractDataUris()
 	c.extractComments()
 
@@ -477,5 +477,5 @@ func (c *CssCompressor) Compress() string {
 	c.Css = bytes.TrimSpace(c.Css)
 
 	// Hooray, we're done!
-	return string(c.Css)
+	return c.Css
 }


### PR DESCRIPTION
time (local)
real    0m0.441s
user    0m0.436s
sys 0m0.000s

time (production server)
real    0m0.900s
user    0m0.888s
sys 0m0.012s

sha1sum old.css 
`d8fd8d435bcef7b85693d4959e22e73b7761e0cc`  old.css

---

time (local)
real    0m0.172s
user    0m0.672s
sys 0m0.004s

time (production server)
real    0m0.265s
user    0m0.896s
sys 0m0.036s

sha1sum new.css 
`d8fd8d435bcef7b85693d4959e22e73b7761e0cc`  new.css
